### PR TITLE
add ipv6 dns

### DIFF
--- a/dnsproxy
+++ b/dnsproxy
@@ -6,8 +6,8 @@ USE_PROCD=1
 
 #####  ONLY CHANGE THIS BLOCK  ######
 PROG=/usr/bin/dnsproxy # where is dnsproxy
-CONF_OVERSEA="-l 127.0.0.1 -p 5335 -u tls://dns.google -u tls://1.1.1.1 -u 202.141.162.123:5353 -b 1.1.1.1:53 --cache --cache-min-ttl=3600 --fastest-addr --ipv6-disabled" # oversea config
-CONF_MAINLAND="-l 127.0.0.1 -p 6050 -u 119.29.29.29 -u 223.5.5.5 -u 180.76.76.76 --cache --cache-min-ttl=3600 --fastest-addr" # mainland config
+CONF_OVERSEA="-l 127.0.0.1 -p 5335 -u tls://dns.google -u tls://1.1.1.1 -u 202.141.162.123:5353 -u 2001:4860:4860::8888 -b 1.1.1.1:53 --cache --cache-min-ttl=3600 --fastest-addr" # oversea config
+CONF_MAINLAND="-l 127.0.0.1 -p 6050 -u 119.29.29.29 -u 223.5.5.5 -u 180.76.76.76 -u 240C::6644 -b 218.2.2.2 -b 240e:5a::6666 --cache --cache-min-ttl=3600 --fastest-addr" # mainland config
 #####  ONLY CHANGE THIS BLOCK  ######
 
 start_service() {


### PR DESCRIPTION
-b 218.2.2.2 -b 240e:5a::6666   [是本地运营商加速bootstrap]
国外添加 --ipv6-disabled 会导致某些国外ipv6 网站无法访问，开启SS后 默认都是ipv4 所以不影响国外，无需关闭ipv6
